### PR TITLE
fix: do not import in close, we get called during garbage collection

### DIFF
--- a/comm/base_comm.py
+++ b/comm/base_comm.py
@@ -6,6 +6,7 @@
 
 import uuid
 import logging
+import comm
 
 from traitlets.utils.importstring import import_item
 
@@ -67,11 +68,10 @@ class BaseComm:
 
     def open(self, data=None, metadata=None, buffers=None):
         """Open the frontend-side version of this comm"""
-        from comm import get_comm_manager
 
         if data is None:
             data = self._open_data
-        comm_manager = get_comm_manager()
+        comm_manager = comm.get_comm_manager()
         if comm_manager is None:
             raise RuntimeError("Comms cannot be opened without a comm_manager.")
 
@@ -92,7 +92,6 @@ class BaseComm:
 
     def close(self, data=None, metadata=None, buffers=None, deleting=False):
         """Close the frontend-side version of this comm"""
-        from comm import get_comm_manager
         if self._closed:
             # only close once
             return
@@ -107,7 +106,7 @@ class BaseComm:
         )
         if not deleting:
             # If deleting, the comm can't be registered
-            get_comm_manager().unregister_comm(self)
+            comm.get_comm_manager().unregister_comm(self)
 
     def send(self, data=None, metadata=None, buffers=None):
         """Send a message to the frontend-side version of this comm"""


### PR DESCRIPTION
I see in solara:
```
Exception ignored in: <function BaseComm.__del__ at 0x111534430>
Traceback (most recent call last):
  File "/Users/maartenbreddels/github/3rd/comm/comm/base_comm.py", line 64, in __del__
  File "/Users/maartenbreddels/github/3rd/comm/comm/base_comm.py", line 95, in close
ImportError: sys.meta_path is None, Python is likely shutting down
```

If instead, we call comm.get_comm_manager we still always get the latest get_comm_manager, but do not do an import at during garbage collection.