### PR TITLE
Loosen dependency on traitlet so it is available in python 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "traitlets>=5.3",
+    "traitlets>=4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Loosen dependency on traitlet so it is available in python 3.6