### PR TITLE
Prevent exception spam during interpreter teardown

### DIFF
--- a/comm/base_comm.py
+++ b/comm/base_comm.py
@@ -81,7 +81,12 @@ class BaseComm:
 
     def __del__(self) -> None:
         """trigger close on gc"""
-        self.close(deleting=True)
+        try:
+            self.close(deleting=True)
+        except Exception:
+            # any number of things can have gone horribly wrong if we're called during
+            # interpreter teardown, which happens if someone holds onto a comm at module scope
+            pass
 
     # publishing messages
 

--- a/comm/base_comm.py
+++ b/comm/base_comm.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
 
+import contextlib
 import logging
 import typing as t
 import uuid
@@ -81,12 +82,10 @@ class BaseComm:
 
     def __del__(self) -> None:
         """trigger close on gc"""
-        try:
+        with contextlib.suppress(Exception):
+            # any number of things can have gone horribly wrong
+            # when called during interpreter teardown
             self.close(deleting=True)
-        except Exception:
-            # any number of things can have gone horribly wrong if we're called during
-            # interpreter teardown, which happens if someone holds onto a comm at module scope
-            pass
 
     # publishing messages
 


### PR DESCRIPTION
Minimal reproducer:

```python
import sys

from ipykernel.comm import Comm

# simply construct a Comm object
Comm(show_warning=False)

# someone somewhere in some other module somehow takes a copy of the modules dict
MODULES_COPY = dict(sys.modules)
```

Slightly more real-world example (how we actually got here):
```python
import sys

# someone somewhere is using dash
import dash

# someone somewhere in some other module somehow takes a copy of the modules dict
MODULES_COPY = dict(sys.modules)
```

These will both output:
```
Exception ignored in: <function BaseComm.__del__ at 0x7f6608e32480>
Traceback (most recent call last):
  File "comm/base_comm.py", line 68, in __del__
  File "comm/base_comm.py", line 104, in close
  File "ipykernel/comm/comm.py", line 26, in publish_msg
AttributeError: 'NoneType' object has no attribute 'initialized'
```

The relevant line is:
```python
if not Kernel.initialized():
    return
```

where `Kernel` is:
```python
from ipykernel.kernelbase import Kernel
```

Due to a series of unfortunate events, the `__del__` for `Comm` is being called _after_ the partial teardown of the `ipykernel.kernelbase` module, as can be seen from the output of `python -v`:

```
# cleanup[3] wiping ipykernel.kernelbase
...
# cleanup[3] wiping comm
Exception ignored in: <function BaseComm.__del__ at 0x7f6608e32480>
Traceback (most recent call last):
  File "comm/base_comm.py", line 68, in __del__
  File "comm/base_comm.py", line 104, in close
  File "ipykernel/comm/comm.py", line 26, in publish_msg
AttributeError: 'NoneType' object has no attribute 'initialized'
```


The above testing was done in a conda environment with:
```
comm-0.1.4-pyhd8ed1ab_0
dash-2.14.2-pyhd8ed1ab_0
ipykernel-6.26.0-pyhf8b6a83_0
python-3.11.6-hab00c5b_0_cpython
```